### PR TITLE
Correctly handle attributes without threshold

### DIFF
--- a/pySMART/attribute.py
+++ b/pySMART/attribute.py
@@ -21,6 +21,7 @@ individual SMART attributes associated with a `Device`.
 """
 
 import re
+from typing import Optional
 
 
 class Attribute(object):
@@ -98,13 +99,13 @@ class Attribute(object):
         return int(self._worst)
 
     @property
-    def thresh(self) -> int:
+    def thresh(self) -> Optional[int]:
         """Gets the threshold value
 
         Returns:
             int: The attribute threshold field in integer format
         """
-        return int(self._thresh)
+        return None if self._thresh == '---' else int(self._thresh)
 
     @property
     def raw_int(self) -> int:


### PR DESCRIPTION
Under some circumstances (see below), smartctl reports attribute thresholds as '---' which previously caused a ValueError.

This patch sets the thresh property to None in that case.

The setup is a Raspbian 10 with smartctl 6.6 and a Western Digital SSD (Model: SA530) attached via a USB bridge.